### PR TITLE
Added 'to have deep value' assertion using hasIn() or getIn()

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,22 @@ This plugin lets you compare [Immutable](https://facebook.github.io/immutable-js
 This library provides `to satisfy` assertions for the above data types. It ensures that they can be compared against each other as well as against comparable JavaScript objects (i.e. `{}` or `[]`).
 
 Indexed types also have most of the assertions of `unexpected`s `array-like` data type (in particular `to have items satisfying`), while keyed types will have most of the `object-like` assertions.
+
+**New assertions**
+
+The `to have deep value at <path>` assertion follows the given path (given either as an array of identifier strings, or as a period- or slash-separated string) to verify its presence. Another argument may be added to provide a value to check equality against. Examples:
+
+```js
+// Checks that there is a key at this location
+expect(collection, 'to have deep value at', ['start', 'user', 'ident']);
+// Checks same location, verifies that value is 'myUser'
+expect(collection, 'to have deep value at', 'start/user/ident', 'myUser');
+```
+
+The `extracting value at <path>` intermediate assertion will attempt to follow the given path into an Immutable collection, allowing further assertions on the value. If it does not exist, the assertion fails. Examples:
+
+```js
+expect(collection, 'extracting value at', ['start', 'user', 'ident'], 'to be ok');
+expect(collection, 'extracting value at', 'start/user/ident', 'to match', /User$/);
+expect(collection, 'extracting value at', 'start.user', 'to satisfy', { ident: 'myUser' });
+```

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ Indexed types also have most of the assertions of `unexpected`s `array-like` dat
 
 **New assertions**
 
-The `to have deep value at <path>` assertion follows the given path (given either as an array of identifier strings, or as a period- or slash-separated string) to verify its presence. Another argument may be added to provide a value to check equality against. Examples:
+The `to have value at <path>` assertion follows the given path (given either as an array of identifier strings, or as a period- or slash-separated string) to verify its presence. Another argument may be added to provide a value to check equality against. Examples:
 
 ```js
 // Checks that there is a key at this location
-expect(collection, 'to have deep value at', ['start', 'user', 'ident']);
+expect(collection, 'to have value at', ['start', 'user', 'ident']);
 // Checks same location, verifies that value is 'myUser'
-expect(collection, 'to have deep value at', 'start/user/ident', 'myUser');
+expect(collection, 'to have value at', 'start/user/ident', 'myUser');
 ```
 
-The `extracting value at <path>` intermediate assertion will attempt to follow the given path into an Immutable collection, allowing further assertions on the value. If it does not exist, the assertion fails. Examples:
+The `value at <path>` intermediate assertion will attempt to follow the given path into an Immutable collection, allowing further assertions on the value. If it does not exist, the assertion fails. Examples:
 
 ```js
-expect(collection, 'extracting value at', ['start', 'user', 'ident'], 'to be ok');
-expect(collection, 'extracting value at', 'start/user/ident', 'to match', /User$/);
-expect(collection, 'extracting value at', 'start.user', 'to satisfy', { ident: 'myUser' });
+expect(collection, 'value at', ['start', 'user', 'ident'], 'to be ok');
+expect(collection, 'value at', 'start/user/ident', 'to match', /User$/);
+expect(collection, 'value at', 'start.user', 'to satisfy', { ident: 'myUser' });
 ```

--- a/lib/unexpected-immutable.js
+++ b/lib/unexpected-immutable.js
@@ -24,13 +24,24 @@ module.exports = {
     expect.addAssertion('<Immutable> to [exhaustively] satisfy <any>', function (expect, subject, pattern) {
       return expect(subject.toJS(), 'to [exhaustively] satisfy', pattern)
     })
-    expect.addAssertion('<Immutable> to have deep value <array> <any?>', function (expect, subject, path, value) {
+    expect.addAssertion('<Immutable> extracting value at <array> <assertion>', function (expect, subject, path) {
+      expect(subject.hasIn(path), 'to be true')
+      return expect.shift(subject.getIn(path))
+    })
+    expect.addAssertion('<Immutable> extracting value at <string> <assertion>', function (expect, subject, pathStr) {
+      const path = pathStr.split(/[./]/)
+      return expect.shift(subject.getIn(path))
+    })
+    expect.addAssertion('<Immutable> to have deep value <array|string> <any?>', function (expect, subject, path, value) {
       if (value !== undefined) {
         expect.argsOutput = function (output) {
           output.text('of ').appendInspected(value).text(' at ').appendInspected(path)
         }
-        return expect(subject.getIn(path), 'to equal', value)
+        return expect(subject, 'extracting value at', path, 'to equal', value)
       } else {
+        if (typeof path === 'string') {
+          path = path.split(/[./]/)
+        }
         return expect(subject.hasIn(path), 'to be true')
       }
     })

--- a/lib/unexpected-immutable.js
+++ b/lib/unexpected-immutable.js
@@ -24,25 +24,23 @@ module.exports = {
     expect.addAssertion('<Immutable> to [exhaustively] satisfy <any>', function (expect, subject, pattern) {
       return expect(subject.toJS(), 'to [exhaustively] satisfy', pattern)
     })
-    expect.addAssertion('<Immutable> extracting value at <array> <assertion>', function (expect, subject, path) {
+    expect.addAssertion('<Immutable> value at <array> <assertion>', function (expect, subject, path) {
       expect(subject.hasIn(path), 'to be true')
       return expect.shift(subject.getIn(path))
     })
-    expect.addAssertion('<Immutable> extracting value at <string> <assertion>', function (expect, subject, pathStr) {
+    expect.addAssertion('<Immutable> value at <string> <assertion>', function (expect, subject, pathStr) {
       const path = pathStr.split(/[./]/)
       return expect.shift(subject.getIn(path))
     })
-    expect.addAssertion('<Immutable> to have deep value <array|string> <any?>', function (expect, subject, path, value) {
+    expect.addAssertion('<Immutable> to have value at <array|string> <any?>', function (expect, subject, path, value) {
       if (value !== undefined) {
         expect.argsOutput = function (output) {
-          output.text('of ').appendInspected(value).text(' at ').appendInspected(path)
+          output.appendInspected(path).text(' of ').appendInspected(value)
         }
-        return expect(subject, 'extracting value at', path, 'to equal', value)
+        return expect(subject, 'value at', path, 'to equal', value)
       } else {
-        if (typeof path === 'string') {
-          path = path.split(/[./]/)
-        }
-        return expect(subject.hasIn(path), 'to be true')
+        const pathArray = (typeof path === 'string') ? path.split(/[./]/) : path
+        return expect(subject.hasIn(pathArray), 'to be true')
       }
     })
 

--- a/lib/unexpected-immutable.js
+++ b/lib/unexpected-immutable.js
@@ -26,7 +26,7 @@ module.exports = {
     })
     expect.addAssertion('<Immutable> to have deep value <array> <any?>', function (expect, subject, path, value) {
       if (value !== undefined) {
-        expect.argsOutput = (output) => {
+        expect.argsOutput = function (output) {
           output.text('of ').appendInspected(value).text(' at ').appendInspected(path)
         }
         return expect(subject.getIn(path), 'to equal', value)

--- a/lib/unexpected-immutable.js
+++ b/lib/unexpected-immutable.js
@@ -27,8 +27,8 @@ module.exports = {
     expect.addAssertion('<Immutable> to have deep value <array> <any?>', function (expect, subject, path, value) {
       if (value !== undefined) {
         expect.argsOutput = (output) => {
-          output.text('of ').appendInspected(value).text(' at ').appendInspected(path);
-        };
+          output.text('of ').appendInspected(value).text(' at ').appendInspected(path)
+        }
         return expect(subject.getIn(path), 'to equal', value)
       } else {
         return expect(subject.hasIn(path), 'to be true')

--- a/lib/unexpected-immutable.js
+++ b/lib/unexpected-immutable.js
@@ -24,6 +24,16 @@ module.exports = {
     expect.addAssertion('<Immutable> to [exhaustively] satisfy <any>', function (expect, subject, pattern) {
       return expect(subject.toJS(), 'to [exhaustively] satisfy', pattern)
     })
+    expect.addAssertion('<Immutable> to have deep value <array> <any?>', function (expect, subject, path, value) {
+      if (value !== undefined) {
+        expect.argsOutput = (output) => {
+          output.text('of ').appendInspected(value).text(' at ').appendInspected(path);
+        };
+        return expect(subject.getIn(path), 'to equal', value)
+      } else {
+        return expect(subject.hasIn(path), 'to be true')
+      }
+    })
 
     expect.addType({
       name: 'ImmutableKeyed',

--- a/test/unexpected-immutable-test.js
+++ b/test/unexpected-immutable-test.js
@@ -166,6 +166,87 @@ test('<Immutable> to exhaustively satisfy <any>, diff', () =>
   )
 )
 
+test('<Immutable> extracting value at <array> <assertion>, pass', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'extracting value at',
+        ['a', 'b', 'c'],
+        'to be', 1
+      ),
+      'not to error'
+    )
+)
+
+test('<Immutable> extracting value at <array> <assertion>, diff', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'extracting value at',
+        ['a', 'b', 'd'],
+        'to be', 1
+      ),
+    'to error',
+    'expected Map { a: Map ... } extracting value at [ \'a\', \'b\', \'d\' ] to be 1'
+  )
+)
+
+test('<Immutable> extracting value at <string> <assertion>, period delimited, pass', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'extracting value at',
+        'a.b.c',
+        'to be', 1
+      ),
+      'not to error'
+    )
+)
+
+test('<Immutable> extracting value at <string> <assertion>, period delimited, diff', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'extracting value at',
+        'a.b.d',
+        'to be', 1
+      ),
+    'to error',
+    'expected Map { a: Map ... } extracting value at \'a.b.d\' to be 1'
+  )
+)
+
+test('<Immutable> extracting value at <string> <assertion>, slash delimited, pass', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'extracting value at',
+        'a/b/c',
+        'to be', 1
+      ),
+      'not to error'
+    )
+)
+
+test('<Immutable> extracting value at <string> <assertion>, slash delimited, diff', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'extracting value at',
+        'a/b/d',
+        'to be', 1
+      ),
+    'to error',
+    'expected Map { a: Map ... } extracting value at \'a/b/d\' to be 1'
+  )
+)
+
 test('<Immutable> to have deep value <array>, passing', () =>
   expect(
     () =>
@@ -204,7 +285,7 @@ test('<Immutable> to have deep value <array> <any>, passing', () =>
   )
 )
 
-test('<Immutable> to have deep value <array>, diff', () =>
+test('<Immutable> to have deep value <array> <any>, diff', () =>
   expect(
     () =>
       expect(
@@ -215,5 +296,57 @@ test('<Immutable> to have deep value <array>, diff', () =>
       ),
     'to error',
     'expected Map { a: Map ... } to have deep value of 1 at [ \'a\', \'b\', \'d\' ]'
+  )
+)
+
+test('<Immutable> to have deep value <string>, passing', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        'a.b.c'
+      ),
+    'not to error'
+  )
+)
+
+test('<Immutable> to have deep value <string>, diff', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        'a.b.d'
+      ),
+    'to error',
+    'expected Map { a: Map ... } to have deep value \'a.b.d\''
+  )
+)
+
+test('<Immutable> to have deep value <string> <any>, passing', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        'a.b.c',
+        1
+      ),
+    'not to error'
+  )
+)
+
+test('<Immutable> to have deep value <string> <any>, diff', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        'a.b.d',
+        1
+      ),
+    'to error',
+    'expected Map { a: Map ... } to have deep value of 1 at \'a.b.d\''
   )
 )

--- a/test/unexpected-immutable-test.js
+++ b/test/unexpected-immutable-test.js
@@ -166,12 +166,12 @@ test('<Immutable> to exhaustively satisfy <any>, diff', () =>
   )
 )
 
-test('<Immutable> extracting value at <array> <assertion>, pass', () =>
+test('<Immutable> value at <array> <assertion>, pass', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'extracting value at',
+        'value at',
         ['a', 'b', 'c'],
         'to be', 1
       ),
@@ -179,26 +179,26 @@ test('<Immutable> extracting value at <array> <assertion>, pass', () =>
     )
 )
 
-test('<Immutable> extracting value at <array> <assertion>, diff', () =>
+test('<Immutable> value at <array> <assertion>, diff', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'extracting value at',
+        'value at',
         ['a', 'b', 'd'],
         'to be', 1
       ),
     'to error',
-    'expected Map { a: Map ... } extracting value at [ \'a\', \'b\', \'d\' ] to be 1'
+    'expected Map { a: Map ... } value at [ \'a\', \'b\', \'d\' ] to be 1'
   )
 )
 
-test('<Immutable> extracting value at <string> <assertion>, period delimited, pass', () =>
+test('<Immutable> value at <string> <assertion>, period delimited, pass', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'extracting value at',
+        'value at',
         'a.b.c',
         'to be', 1
       ),
@@ -206,26 +206,26 @@ test('<Immutable> extracting value at <string> <assertion>, period delimited, pa
     )
 )
 
-test('<Immutable> extracting value at <string> <assertion>, period delimited, diff', () =>
+test('<Immutable> value at <string> <assertion>, period delimited, diff', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'extracting value at',
+        'value at',
         'a.b.d',
         'to be', 1
       ),
     'to error',
-    'expected Map { a: Map ... } extracting value at \'a.b.d\' to be 1'
+    'expected Map { a: Map ... } value at \'a.b.d\' to be 1'
   )
 )
 
-test('<Immutable> extracting value at <string> <assertion>, slash delimited, pass', () =>
+test('<Immutable> value at <string> <assertion>, slash delimited, pass', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'extracting value at',
+        'value at',
         'a/b/c',
         'to be', 1
       ),
@@ -233,51 +233,51 @@ test('<Immutable> extracting value at <string> <assertion>, slash delimited, pas
     )
 )
 
-test('<Immutable> extracting value at <string> <assertion>, slash delimited, diff', () =>
+test('<Immutable> value at <string> <assertion>, slash delimited, diff', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'extracting value at',
+        'value at',
         'a/b/d',
         'to be', 1
       ),
     'to error',
-    'expected Map { a: Map ... } extracting value at \'a/b/d\' to be 1'
+    'expected Map { a: Map ... } value at \'a/b/d\' to be 1'
   )
 )
 
-test('<Immutable> to have deep value <array>, passing', () =>
+test('<Immutable> to have value at <array>, passing', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         ['a', 'b', 'c']
       ),
     'not to error'
   )
 )
 
-test('<Immutable> to have deep value <array>, diff', () =>
+test('<Immutable> to have value at <array>, diff', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         ['a', 'b', 'd']
       ),
     'to error',
-    'expected Map { a: Map ... } to have deep value [ \'a\', \'b\', \'d\' ]'
+    'expected Map { a: Map ... } to have value at [ \'a\', \'b\', \'d\' ]'
   )
 )
 
-test('<Immutable> to have deep value <array> <any>, passing', () =>
+test('<Immutable> to have value at <array> <any>, passing', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         ['a', 'b', 'c'],
         1
       ),
@@ -285,51 +285,51 @@ test('<Immutable> to have deep value <array> <any>, passing', () =>
   )
 )
 
-test('<Immutable> to have deep value <array> <any>, diff', () =>
+test('<Immutable> to have value at <array> <any>, diff', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         ['a', 'b', 'd'],
         1
       ),
     'to error',
-    'expected Map { a: Map ... } to have deep value of 1 at [ \'a\', \'b\', \'d\' ]'
+    'expected Map { a: Map ... } to have value at [ \'a\', \'b\', \'d\' ] of 1'
   )
 )
 
-test('<Immutable> to have deep value <string>, passing', () =>
+test('<Immutable> to have value at <string>, passing', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         'a.b.c'
       ),
     'not to error'
   )
 )
 
-test('<Immutable> to have deep value <string>, diff', () =>
+test('<Immutable> to have value at <string>, diff', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         'a.b.d'
       ),
     'to error',
-    'expected Map { a: Map ... } to have deep value \'a.b.d\''
+    'expected Map { a: Map ... } to have value at \'a.b.d\''
   )
 )
 
-test('<Immutable> to have deep value <string> <any>, passing', () =>
+test('<Immutable> to have value at <string> <any>, passing', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         'a.b.c',
         1
       ),
@@ -337,16 +337,16 @@ test('<Immutable> to have deep value <string> <any>, passing', () =>
   )
 )
 
-test('<Immutable> to have deep value <string> <any>, diff', () =>
+test('<Immutable> to have value at <string> <any>, diff', () =>
   expect(
     () =>
       expect(
         new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
-        'to have deep value',
+        'to have value at',
         'a.b.d',
         1
       ),
     'to error',
-    'expected Map { a: Map ... } to have deep value of 1 at \'a.b.d\''
+    'expected Map { a: Map ... } to have value at \'a.b.d\' of 1'
   )
 )

--- a/test/unexpected-immutable-test.js
+++ b/test/unexpected-immutable-test.js
@@ -165,3 +165,55 @@ test('<Immutable> to exhaustively satisfy <any>, diff', () =>
     '}'
   )
 )
+
+test('<Immutable> to have deep value <array>, passing', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        ['a', 'b', 'c']
+      ),
+    'not to error'
+  )
+)
+
+test('<Immutable> to have deep value <array>, diff', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        ['a', 'b', 'd']
+      ),
+    'to error',
+    'expected Map { a: Map ... } to have deep value [ \'a\', \'b\', \'d\' ]'
+  )
+)
+
+test('<Immutable> to have deep value <array> <any>, passing', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        ['a', 'b', 'c'],
+        1
+      ),
+    'not to error'
+  )
+)
+
+test('<Immutable> to have deep value <array>, diff', () =>
+  expect(
+    () =>
+      expect(
+        new Map({ a: new Map({ b: new Map({ c: 1 }) }) }),
+        'to have deep value',
+        ['a', 'b', 'd'],
+        1
+      ),
+    'to error',
+    'expected Map { a: Map ... } to have deep value of 1 at [ \'a\', \'b\', \'d\' ]'
+  )
+)


### PR DESCRIPTION
I found I had a use for an assertion that tests for presence or value of a key in a deep immutable structure. So I constructed `<Immutable> to have deep value <array> <any?>`. The array is a path array, as used by `Collection#hasIn()` or `#getIn()`, the value, optionally, is the value expected to be found there. If left out (or set to `undefined` `hasIn()` is used, if included, `getIn() is used to extract the value, and it is then tested against using `'to equal'`.