### PR TITLE
Update to Unexpected 11

### DIFF
--- a/__tests__/immutable-base.spec.js
+++ b/__tests__/immutable-base.spec.js
@@ -1,4 +1,4 @@
-import expect from 'unexpected'
+import expect from '../expect'
 import Immutable, { Map, List } from 'immutable'
 
 test('Equality of two Maps', () =>

--- a/__tests__/immutable-indexed.spec.js
+++ b/__tests__/immutable-indexed.spec.js
@@ -1,4 +1,4 @@
-import expect from 'unexpected'
+import expect from '../expect'
 import { List } from 'immutable'
 
 test('<ImmutableIndexed> to have items [exhaustively] satisfying <any>, passing', () =>

--- a/__tests__/immutable-keyed.spec.js
+++ b/__tests__/immutable-keyed.spec.js
@@ -1,4 +1,4 @@
-import expect from 'unexpected'
+import expect from '../expect'
 import { Map } from 'immutable'
 
 test('<ImmutableKeyed> to have values satisfying <any>, passing', () =>

--- a/expect.js
+++ b/expect.js
@@ -1,5 +1,8 @@
 import unexpected from 'unexpected'
 import unexpectedImmutable from './lib/unexpected-immutable'
 
-unexpected.use(unexpectedImmutable)
+const expect = unexpected.clone()
+  .use(unexpectedImmutable)
 unexpected.output.preferredWidth = 150
+
+export default expect

--- a/expect.js
+++ b/expect.js
@@ -1,8 +1,8 @@
 import unexpected from 'unexpected'
 import unexpectedImmutable from './lib/unexpected-immutable'
 
+unexpected.output.preferredWidth = 150
 const expect = unexpected.clone()
   .use(unexpectedImmutable)
-unexpected.output.preferredWidth = 150
 
 export default expect

--- a/package-lock.json
+++ b/package-lock.json
@@ -5818,16 +5818,16 @@
       }
     },
     "unexpected": {
-      "version": "10.40.2",
-      "resolved": "https://registry.npmjs.org/unexpected/-/unexpected-10.40.2.tgz",
-      "integrity": "sha512-xwLScBxEnHiK8H8yLblQ6u3Uoammhpk+oCB/HWiNY6exMEwxenUR+eWIKderEXQPOlZkUEakBAKborGJqK6hZQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/unexpected/-/unexpected-11.0.1.tgz",
+      "integrity": "sha512-INflDVZTLwqvHQk/g4huzEU7/AIZwkK7ezNbt1Nb3CFeCbgtPPr69Lxb5FW1RydrLQ1Ua18P6LpPvO1oCDHfGw==",
       "dev": true,
       "requires": {
         "array-changes": "3.0.1",
         "array-changes-async": "3.0.1",
         "babel-runtime": "6.26.0",
         "detect-indent": "3.0.1",
-        "diff": "1.1.0",
+        "diff": "4.0.1",
         "greedy-interval-packer": "1.2.0",
         "leven": "2.1.0",
         "magicpen": "5.12.0",
@@ -5846,9 +5846,9 @@
           }
         },
         "diff": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-1.1.0.tgz",
-          "integrity": "sha1-eYpJOBqkZBUem08Ob/Kwmooa0j8=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         },
         "get-stdin": {

--- a/package.json
+++ b/package.json
@@ -51,9 +51,6 @@
     "ignore": "build"
   },
   "jest": {
-    "setupFiles": [
-      "<rootDir>/test_setup.js"
-    ],
     "cacheDirectory": "<rootDir>/.cache"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/erikmueller/unexpected-immutable#readme",
   "peerDependencies": {
-    "unexpected": "^10.0.0",
+    "unexpected": "^10.0.0 || ^11.0.0",
     "immutable": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "rollup-plugin-babel": "^2.7.1",
     "snazzy": "^7.0.0",
     "standard": "^10.0.2",
-    "unexpected": "^10.0.0"
+    "unexpected": "^11.0.1"
   },
   "standard": {
     "env": "jest",


### PR DESCRIPTION
... And announce compatibility with it in `peerDependencies`.

Turns out no code changes are actually necessary. I just dived in because we started seeing errors when updating to the latest version and assumed that it was due to Unexpected 11.