### PR TITLE
Don't rely on expect.addAssertion and expect.addType being bound

### DIFF
--- a/lib/unexpected-immutable.js
+++ b/lib/unexpected-immutable.js
@@ -16,7 +16,7 @@ const assertions = [
 export default {
   name: 'unexpected-immutable',
   installInto: function (expect) {
-    types.forEach(type => expect.addType.call(null, type))
-    assertions.forEach(assertion => expect.addAssertion.apply(null, assertion))
+    types.forEach(type => expect.addType(type))
+    assertions.forEach(assertion => expect.addAssertion.apply(expect, assertion))
   }
 }


### PR DESCRIPTION
Fixed compatibility with unexpected 11.2+

It breaks because of unexpectedjs/unexpected#565